### PR TITLE
Bv2.5.5

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "GAD",
-  "version": "v2.5.4",
+  "version": "v2.5.5",
   "description": "Simple application prepared and developed only for testing purposes",
   "repository": "https://github.com/jaktestowac/gad-gui-api-demo",
   "keywords": ["json-server", "node", "REST API", "UI", "JavaScript", "testing"],

--- a/helpers/compare.helpers.js
+++ b/helpers/compare.helpers.js
@@ -1,5 +1,5 @@
 function areStringsEqualIgnoringCase(str1, str2) {
-  return str1?.toLowerCase() === str2?.toLowerCase();
+  return `${str1}`.toLowerCase() === `${str2}`.toLowerCase();
 }
 
 function areIdsEqual(id1, id2) {

--- a/helpers/compare.helpers.js
+++ b/helpers/compare.helpers.js
@@ -1,5 +1,5 @@
 function areStringsEqualIgnoringCase(str1, str2) {
-  return `${str1}`.toLowerCase() === `${str2}`.toLowerCase();
+  return str1 !== undefined && `${str1}`.toLowerCase() === `${str2}`.toLowerCase();
 }
 
 function areIdsEqual(id1, id2) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gad-gui-api-demo-v2",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Simple application with GUI and API to deploy to Heroku, Glitch, Railway, Vercel etc.",
   "main": "server.js",
   "scripts": {

--- a/public/version.js
+++ b/public/version.js
@@ -1,6 +1,6 @@
 const versionElement = document.querySelector("#version");
 
-const appVersion = "v2.5.4";
+const appVersion = "v2.5.5";
 
 if (versionElement) {
   versionElement.innerHTML = appVersion;

--- a/tests/test/login.spec.js
+++ b/tests/test/login.spec.js
@@ -35,28 +35,32 @@ describe("Endpoint /login", () => {
     expect(response.status).to.equal(401);
   });
 
-  it("POST /login - invalid pass", async () => {
-    // Arrange:
-    const userData = generateValidUserLoginData();
-    userData.password = "";
+  ["", 0, true, undefined].forEach((testValue) => {
+    it(`POST /login - invalid pass - "${testValue}"`, async () => {
+      // Arrange:
+      const userData = generateValidUserLoginData();
+      userData.password = testValue;
 
-    // Act:
-    const response = await request.post(baseUrl).send(userData);
+      // Act:
+      const response = await request.post(baseUrl).send(userData);
 
-    // Assert:
-    expect(response.status).to.equal(401);
+      // Assert:
+      expect(response.status).to.equal(401);
+    });
   });
 
-  it("POST /login - invalid email", async () => {
-    // Arrange:
-    const userData = generateValidUserLoginData();
-    userData.email = "";
+  ["", 0, true, undefined].forEach((testValue) => {
+    it(`POST /login - invalid email - "${testValue}"`, async () => {
+      // Arrange:
+      const userData = generateValidUserLoginData();
+      userData.email = testValue;
 
-    // Act:
-    const response = await request.post(baseUrl).send(userData);
+      // Act:
+      const response = await request.post(baseUrl).send(userData);
 
-    // Assert:
-    expect(response.status).to.equal(401);
+      // Assert:
+      expect(response.status).to.equal(401);
+    });
   });
 
   it("POST /login - invalid data", async () => {


### PR DESCRIPTION
Bugfix:

- string compare causing error when bool or number was provided instead of string

![obraz](https://github.com/jaktestowac/gad-gui-api-demo/assets/18641516/87aff7e2-2cf5-40c1-af52-e9c989b3e6e3)