### PR TITLE
feat: allow order cancellation when the cart is empty

### DIFF
--- a/endpoints/book-shop/book-shop-orders-endpoint.helpers.js
+++ b/endpoints/book-shop/book-shop-orders-endpoint.helpers.js
@@ -334,7 +334,10 @@ function handleBookShopOrders(req, res, isAdmin) {
       return false;
     }
 
-    if (orderBase.book_ids.length === 0 && areIdsEqual(currentOrderStatus.id, orderStatuses.new) === true) {
+    if (orderBase.book_ids.length === 0 && 
+      areIdsEqual(currentOrderStatus.id, orderStatuses.new) === true  &&
+      areIdsEqual(newStatusId, orderStatuses.cancelled) === false
+    ) {
       res.status(HTTP_UNPROCESSABLE_ENTITY).send(formatErrorResponse("Order has no items"));
       return false;
     }


### PR DESCRIPTION
There is no possibility to cancel new order without books. Here is a fix.